### PR TITLE
correctly use configuration file if provided on the CLI

### DIFF
--- a/src/pyNmonAnalyzer.py
+++ b/src/pyNmonAnalyzer.py
@@ -50,7 +50,7 @@ class pyNmonAnalyzer:
 		if self.args.defaultConf:
 			# write out default report and exit
 			log.warn("Note: writing default report config file to " + self.args.confFname)
-			self.saveReportConfig(self.stdReport)
+			self.saveReportConfig(self.stdReport, configFname=self.args.confFname)
 			sys.exit()
 		
 		if self.args.buildReport:
@@ -60,7 +60,7 @@ class pyNmonAnalyzer:
 				ans = raw_input("\t Would you like us to write the default file out for you? [y/n]:")
 				
 				if ans.strip().lower() == "y":
-					self.saveReportConfig(self.stdReport)
+					self.saveReportConfig(self.stdReport, configFname=self.args.confFname)
 					log.warn("Wrote default config to report.config.")
 					log.warn("Please adjust report.config to ensure the correct devices will be graphed.")
 				else:


### PR DESCRIPTION
Hello,

this pull request fix the following bug:
- if configfile is specified on the CLI, the script still test the presence of ./report.config instead of the specified file
- if configfile is specified on the CLI and does not exist, the default config file is written as ./report.config file instead of the specified file
- if --defaultconfig is used in conjunction with -r configfile, the default config file is written as ./report.config file instead of the specified file

Also, it would facilitate contribution if your code was respecting PEP8 specification.

Regards,
John
